### PR TITLE
Fix typo in homepage.

### DIFF
--- a/index.md
+++ b/index.md
@@ -64,7 +64,7 @@ Can include:
 - Additional speaker: you can add co-author
 - Extra review material: private materials you want to show to reviewers
 
-Please make sure to add links to relevant online materials (such as website, publications, code ripository...) to either abstract or extra review material.
+Please make sure to add links to relevant online materials (such as website, publications, code repository...) to either abstract or extra review material.
    
 
 To get inspired on possible abstracts style, length and format, you can read previous edition talks on FOSDEM archives:


### PR DESCRIPTION
This PR addresses issue #22.

**Observed behaviour:**
Line 67 in `index.md` contained a misspelled word "_ripository_".

**Expected behaviour:**
The word was changed to "repository" in this commit.
![screenshot of change made in commit](https://github.com/research-fosdem/research-fosdem.github.io/assets/105166953/d2239982-5181-48e2-9c5a-08256e15282f)

Thanks for reviewing!